### PR TITLE
Fix for JS bundling problem

### DIFF
--- a/dist/ng-input-currency.js
+++ b/dist/ng-input-currency.js
@@ -108,4 +108,4 @@ angular.module('ngInputCurrency').directive('ngInputCurrency', ['$locale','$filt
   };
 }]);
 
-},{}]},{},[1])
+},{}]},{},[1]);


### PR DESCRIPTION
First of all, great tool thank you for this! :)
Me and some of my co workers are using this project and we all noticed that whenever we include this library in a bundling script, our program crashes. Later I found out that it is caused by not having a semi colon at the end of the script. Apparently, there is no problem on my workflow if this library is bundled at the very bottom of the script but if this is in between two different scripts all the scripts below this library will failed to load.